### PR TITLE
Require user to login to back project #146571373

### DIFF
--- a/app/controllers/payments_controller.rb
+++ b/app/controllers/payments_controller.rb
@@ -1,7 +1,6 @@
 class PaymentsController < ApplicationController
 
   def new
-
     @reward = Reward.find(params[:reward_id])
   end
 

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -15,6 +15,8 @@ class SessionsController < ApplicationController
     if confirmation_matches && login(params[:email], params[:password])
       flash[:success] = 'Welcome back!'
       redirect_to root_path
+      # redirect_to request.referer || root_path
+      # redirect_back(fallback_location: root_path)
     else
       flash.now[:warning] = 'E-mail and/or password is incorrect.'
       render 'new'

--- a/app/views/rewards/_rewards_list.html.erb
+++ b/app/views/rewards/_rewards_list.html.erb
@@ -1,5 +1,8 @@
 <div class="card blue-grey lighten-3 rewards_list container">
 
+<% if current_user == nil %>
+  <%= link_to "Please log in to continue", login_path %>
+<% else %>
   <% @project.rewards.each do |reward| %>
   <div class="card-content">
     <span class="card-title"> <%= reward.title %></span>
@@ -8,4 +11,5 @@
       <%= link_to "Continue", checkout_path(reward), class: "waves-effect waves-light btn" %>
   </div>
   <% end %>
+<% end %>
 </div>


### PR DESCRIPTION
#### What does  this PR do?
requires users to login on the rewards page before being allowed to select rewards package to complete project-backing process
#### Where should the reviewer start?
at the top!
#### How should this be manually tested?
fire up the local server and navigate from root path to a project, and click on "back this project". on the next page, you'll be prompted to select a reward if logged in OR log in if not logged in. 
#### Any background context you want to provide?
I still have "redirect_back" and some other commented out code in the sessions controller b/c I can't get the referrer to go back 2 pages to drop user on the rewards page they were on when they were prompted to log in.
#### What are the relevant tickets?
#146571373
#### Screenshots (if appropriate)
#### Questions:
  - Do Migrations Need to be ran? nope
  - Do Environment Variables need to be set? nope
  - Any other deploy steps? none