### PR TITLE
User Can Edit Their Own Projects

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,4 +6,13 @@ class ApplicationController < ActionController::Base
       flash[:warning] = "Please log in to continue!"
       redirect_to login_path
     end
+
+    def check_project_owner(project)
+      redirect_page_not_found unless current_user.owner?(project)
+    end
+
+    def redirect_page_not_found
+      flash[:alert] = "Page not found!"
+      render :file => 'public/404.html', :status => :not_found
+    end
 end

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -16,7 +16,7 @@ class ProjectsController < ApplicationController
       name: params[:project][:city],
       country_id: params[:project][:country_id])
     params[:project].merge!({city_id: city.id})
-    @project = current_user.projects.new(project_params)
+    @project = current_user.projects.create(project_params)
 
     if @project.save
       redirect_to new_reward_path(project_id: @project.id)

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -1,5 +1,5 @@
 class ProjectsController < ApplicationController
-  before_action :require_login, only: [:new]
+  before_action :require_login, only: [:new, :edit]
   before_action :set_categories, only: [:new]
   before_action :set_countries, only: [:new]
 

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -28,7 +28,25 @@ class ProjectsController < ApplicationController
 
   def edit
     @project = Project.find(params[:id])
+    check_project_owner(@project)
   end
+
+  def update
+    city = City.find_or_create_by(
+      name: params[:project][:city],
+      country_id: params[:project][:country_id])
+    params[:project].merge!({city_id: city.id})
+    @project = Project.find(params[:id])
+    @project.update(project_params)
+
+    if @project.save
+      redirect_to project_path(@project)
+    else
+      redirect_to new_project_path
+      flash[:warning] = "Please fill in all fields."
+    end
+  end
+
 
   private
     def project_params

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -4,9 +4,12 @@ class Project < ApplicationRecord
   belongs_to :city
   belongs_to :country
   belongs_to :category, required: false
+
   has_many   :project_owners
   has_many   :owners, through: :project_owners, source: :user
+
   has_many   :rewards
+
   has_many   :project_backers
   has_many   :backers, through: :project_backers, source: :user
 
@@ -49,7 +52,7 @@ class Project < ApplicationRecord
   def self.most_funded
     Project.joins(:project_backers).group(:id).order('sum(pledge_amount)desc').first
   end
-  
+
   def days_remaining
    (Date.parse(end_date) - Date.today).to_s
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -15,4 +15,8 @@ class User < ApplicationRecord
   has_many :backed_projects, through: :project_backers, source: :project
 
   has_many :rewards, through: :project_backers
+
+  def owner?(project)
+    projects.include?(project)
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,9 +7,12 @@ class User < ApplicationRecord
   validates :email, presence: true
   validates :email, uniqueness: true, case_sensitive: false
   validates :name, presence: true
+
   has_many :project_owners
   has_many :projects, through: :project_owners
+
   has_many :project_backers
   has_many :backed_projects, through: :project_backers, source: :project
+
   has_many :rewards, through: :project_backers
 end

--- a/app/views/helpers/_project_card.html.erb
+++ b/app/views/helpers/_project_card.html.erb
@@ -9,7 +9,8 @@
     </div>
     <div class="card-reveal">
       <span class="card-title grey-text text-darken-4"><%= project.title %><i class="material-icons right">close</i></span>
-      <%= project.description %>
+      <p><%= project.description %></p>
+      <%= render partial: 'helpers/project_edit', locals: {project: project} if current_user.owner?(project) %>
     </div>
   </div>
   <% end %>

--- a/app/views/helpers/_project_edit.html.erb
+++ b/app/views/helpers/_project_edit.html.erb
@@ -1,0 +1,1 @@
+<%= link_to "Edit", edit_project_path(project) %>

--- a/app/views/layouts/_navbar.html.erb
+++ b/app/views/layouts/_navbar.html.erb
@@ -15,7 +15,7 @@
 
 			<li><%= link_to 'All Projects', root_path  %></li>
       <li><a class="dropdown-button" href="#!" data-activates="dropdown1">Categories<i class="material-icons right">arrow_drop_down</i></a></li>
-			<li><a href="projects/new">Start a project</a></li>
+			<li><%= link_to "Start a project", new_project_path %></li>
 			<%= link_to((image_tag "logo 1", class: "brand-logo center", width: "225"), root_path) %>
 		</ul>
 

--- a/app/views/projects/edit.html.erb
+++ b/app/views/projects/edit.html.erb
@@ -1,3 +1,41 @@
-<h1>Welcome!</h1>
+<div class="container">
+  <h1>Edit Your Project</h1>
+  <%= form_for @project do |f| %>
 
-<p> restricted area for autherized users only. </p>
+    <%= f.label :title %>
+    <%= f.text_field :title %>
+
+    <%= f.label :description %>
+    <%= f.text_field :description %>
+
+    <%= f.label :image_url%>
+    <%= f.text_field :image_url%>
+
+    <%= f.label :target_amount%>
+    <%= f.text_field :target_amount%>
+
+    <%= f.label :category %>
+    <%= f.collection_select :category_id,
+    Category.all.order(:name),
+    :id,
+    :name,
+    include_blank: true %><br>
+
+    <%= f.label :city %>
+    <%= f.text_field :city, value: @project.city.name %>
+
+    <%= f.label :country %>
+    <%= f.collection_select :country_id,
+                            Country.all.order(:name),
+                            :id,
+                            :name,
+                            include_blank: true %><br>
+
+    <%= f.label :completion_date%>
+    <%= f.date_select :completion_date,
+                      class: "datepicker",
+                      selected: 30.days.from_now  %>
+
+    <%= f.submit "Save and continue" %>
+  <% end %>
+</div>

--- a/app/views/projects/new.html.erb
+++ b/app/views/projects/new.html.erb
@@ -1,7 +1,5 @@
 <div class="container">
-
   <h1>Create a New Project</h1>
-
   <%= form_for @project do |f| %>
 
     <%= f.label :title %>

--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -28,6 +28,7 @@
           </div>
           <p class="flow-text">
           <%= link_to "All or nothing."%> This project will only be funded if it reaches its goal by <%= @project.end_date_time %>.</p>
+          <%= render partial: 'helpers/project_edit', locals: {project: @project} if current_user && current_user.owner?(@project) %>
         </div>
     </div>
   </div>

--- a/app/views/users/projects/index.html.erb
+++ b/app/views/users/projects/index.html.erb
@@ -16,6 +16,8 @@
   <% end %>
 </div>
 
-
 <h3>Your Puntd Projects</h3>
-<%= render "helpers/project_card" %>
+
+<div class="user-projects">
+  <%= render "helpers/project_card" %>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,7 +13,7 @@ Rails.application.routes.draw do
 
   resources :categories, only: [:index, :show]
   resources :rewards, only: [:index, :create, :new]
-  resources :projects, only: [:index, :show, :edit, :new, :create]
+  resources :projects, only: [:index, :show, :edit, :new, :create, :update]
 
   namespace :projects do
     get '/:project_id/rewards', to: "rewards#index", as: "rewards"

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -10,5 +10,8 @@ FactoryGirl.define do
     factory :user_with_projects do
       projects {create_list(:project, 2)}
     end
+    factory :user_with_a_project do
+      projects {create_list(:project, 1)}
+    end
   end
 end

--- a/spec/features/user_can_create_project_spec.rb
+++ b/spec/features/user_can_create_project_spec.rb
@@ -1,8 +1,13 @@
 require 'rails_helper'
 
 describe "user can create a project" do
+  attr_reader :image_url, :category, :country, :city, :date, :image_url
   before :each do
     create(:project)
+    @category = create(:category)
+    @country = create(:country)
+    @city = create(:city)
+    @image_url =  Faker::Avatar.image
   end
   context "when a user is logged in" do
     it "takes user to new project page" do
@@ -14,6 +19,48 @@ describe "user can create a project" do
 
         expect(current_path).to eq new_project_path
       end
+    end
+    it "displays project in user profile page" do
+      user = create(:user)
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
+
+      visit new_project_path
+
+      select category.name,                from: 'project_category_id'
+      fill_in 'project[title]',            with: 'Crafters Paradise'
+      fill_in 'project[description]',      with: 'Lots of paint'
+      fill_in 'project[image_url]',        with: image_url
+      fill_in 'project[target_amount]',    with: '10000'
+      fill_in 'project[city]',             with: 'Paris'
+      select country.name,                 from: 'project_country_id'
+
+      click_on 'Save and continue'
+
+      expect(current_path).to eq('/rewards/new')
+      fill_in "reward[title]", with: "Raw Denim Romphim"
+      fill_in "reward[description]", with: "24 ounce Kahari Mills left-hand twill denim"
+      fill_in "reward[pledge_amount]", with: 475
+      fill_in "reward[limit]", with: 1
+
+      click_on 'Save and Continue'
+
+      project = Project.last
+      expect(project.title).to eq('Crafters Paradise')
+      expect(project.owners.count).to eq(1)
+      expect(project.owners.first).to eq(user)
+
+      visit user_path(user)
+
+      expect(page).to have_content("Your Puntd Projects")
+
+      within('.user-projects') do
+        expect(page).to have_selector('.card', count:1)
+        expect(page).to have_content('Crafters Paradise')
+
+        click_on 'Crafters Paradise'
+      end
+
+      expect(current_path).to eq(project_path(project))
     end
   end
 end

--- a/spec/features/user_can_edit_their_projects_spec.rb
+++ b/spec/features/user_can_edit_their_projects_spec.rb
@@ -1,0 +1,78 @@
+require 'rails_helper'
+
+feature "project edit" do
+  let(:user1) {create(:user_with_a_project)}
+  let(:project) {user1.projects.first}
+  let(:user2) {create(:user)}
+  context "from user profile page" do
+    scenario "user can edit their own projects" do
+      # as a user
+      allow_any_instance_of(ApplicationController)
+        .to receive(:current_user)
+        .and_return(user1)
+      # when I am on my profile
+      visit user_path
+      # and I click on the edit button for a project
+      within('.user-projects') do
+        expect(page).to have_selector('project', count: 1)
+        expect(page).to have_link('Edit')
+        click_link 'Edit'
+      end
+      # I am brought to the project edit page
+      expect(current_path).to eq(edit_project_path(project))
+      # and I make a change to the project description
+      fill_in :title, with: "RuPaul is Awesome!"
+      click_on 'Submit'
+      # I am brought to the project's show page
+      expect(current_path).to eq(project_path(project))
+      # and the change is there
+      expect(project.title).to_not eq("RuPaul is Awesome!")
+      expect(page).to have_content("RuPaul is Awesome!")
+      expect(page).to_not have_content(project.title)
+    end
+    xscenario "user cannot edit a project they don't own" do
+      # as another user
+      allow_any_instance_of(ApplicationController)
+        .to receive(:current_user)
+        .and_return(user2)
+      # when I am on my profile page
+      visit user_path
+      # i do not see the link for the other user's project
+      within('.user-projects') do
+        expect(page).to_not have_selector('project')
+        expect(page).to_not have_link('Edit')
+      end
+      # when I visit the edit page anyway
+      visit edit_project_path(project)
+      # i receive a 404 error
+      expect(page.status).to eq(404)
+      expect(page).to have_content("Page Not Found")
+    end
+  end
+  context "from project show page" do
+    xscenario "user can edit their own project" do
+      # as a user
+      allow_any_instance_of(ApplicationController)
+        .to receive(:current_user)
+        .and_return(user1)
+      # when I am on one of my project's show pages
+      visit project_path(project)
+      # i see an edit button
+      expect(page).to have_link('Edit Project')
+      # and I click on the edit button
+      click_link 'Edit Project'
+      # i am brought to the projects edit page
+      expect(current_path).to eq(edit_project_path(project))
+    end
+    xscenario "user cannot see the edit button" do
+      # as another user
+      allow_any_instance_of(ApplicationController)
+        .to receive(:current_user)
+        .and_return(user2)
+      # when I am on a project's show page that i don't own
+      visit project_path(project)
+      # i do not see an edit button
+      expect(page).to_not have_link('Edit Project')
+    end
+  end
+end

--- a/spec/features/user_can_edit_their_projects_spec.rb
+++ b/spec/features/user_can_edit_their_projects_spec.rb
@@ -11,46 +11,46 @@ feature "project edit" do
         .to receive(:current_user)
         .and_return(user1)
       # when I am on my profile
-      visit user_path
+      visit user_path(user1)
       # and I click on the edit button for a project
       within('.user-projects') do
-        expect(page).to have_selector('project', count: 1)
+        expect(page).to have_selector('.card', count: 1)
         expect(page).to have_link('Edit')
         click_link 'Edit'
       end
       # I am brought to the project edit page
       expect(current_path).to eq(edit_project_path(project))
       # and I make a change to the project description
-      fill_in :title, with: "RuPaul is Awesome!"
-      click_on 'Submit'
+      fill_in 'Title', with: 'RuPaul is Awesome!'
+      click_on 'Save and continue'
       # I am brought to the project's show page
       expect(current_path).to eq(project_path(project))
       # and the change is there
-      expect(project.title).to_not eq("RuPaul is Awesome!")
-      expect(page).to have_content("RuPaul is Awesome!")
+      expect(project.title).to_not eq('RuPaul is Awesome!')
+      expect(page).to have_content('RuPaul is Awesome!')
       expect(page).to_not have_content(project.title)
     end
-    xscenario "user cannot edit a project they don't own" do
+    scenario "user cannot edit a project they don't own" do
       # as another user
       allow_any_instance_of(ApplicationController)
         .to receive(:current_user)
         .and_return(user2)
       # when I am on my profile page
-      visit user_path
+      visit user_path(user2)
       # i do not see the link for the other user's project
       within('.user-projects') do
-        expect(page).to_not have_selector('project')
+        expect(page).to_not have_selector('card')
         expect(page).to_not have_link('Edit')
       end
       # when I visit the edit page anyway
       visit edit_project_path(project)
       # i receive a 404 error
-      expect(page.status).to eq(404)
-      expect(page).to have_content("Page Not Found")
+      expect(page.status_code).to eq(404)
+      expect(page).to have_content("Page not found!")
     end
   end
   context "from project show page" do
-    xscenario "user can edit their own project" do
+    scenario "user can edit their own project" do
       # as a user
       allow_any_instance_of(ApplicationController)
         .to receive(:current_user)
@@ -58,13 +58,13 @@ feature "project edit" do
       # when I am on one of my project's show pages
       visit project_path(project)
       # i see an edit button
-      expect(page).to have_link('Edit Project')
+      expect(page).to have_link('Edit')
       # and I click on the edit button
-      click_link 'Edit Project'
+      click_link 'Edit'
       # i am brought to the projects edit page
       expect(current_path).to eq(edit_project_path(project))
     end
-    xscenario "user cannot see the edit button" do
+    scenario "user cannot see the edit button" do
       # as another user
       allow_any_instance_of(ApplicationController)
         .to receive(:current_user)
@@ -72,7 +72,7 @@ feature "project edit" do
       # when I am on a project's show page that i don't own
       visit project_path(project)
       # i do not see an edit button
-      expect(page).to_not have_link('Edit Project')
+      expect(page).to_not have_link('Edit')
     end
   end
 end

--- a/spec/features/user_creates_new_reward_spec.rb
+++ b/spec/features/user_creates_new_reward_spec.rb
@@ -29,7 +29,7 @@ RSpec.feature "User adds a new reward to the database" do
       fill_in "reward[pledge_amount]", with: 475
       fill_in "reward[limit]", with: 1
 
-      click_on "Save and Continue"
+      click_on 'Save and continue'
 
       expect(current_path).to eq('/projects/1')
       expect(Reward.last.title).to eq("Raw Denim Romphim")

--- a/spec/features/user_creates_new_reward_spec.rb
+++ b/spec/features/user_creates_new_reward_spec.rb
@@ -29,7 +29,7 @@ RSpec.feature "User adds a new reward to the database" do
       fill_in "reward[pledge_amount]", with: 475
       fill_in "reward[limit]", with: 1
 
-      click_on 'Save and continue'
+      click_on 'Save and Continue'
 
       expect(current_path).to eq('/projects/1')
       expect(Reward.last.title).to eq("Raw Denim Romphim")


### PR DESCRIPTION
#### What does  this PR do?

- Adds tests and fixes issues relating to users creating projects in the first place.
- Adds a project edit form.
- Allows users to chose to edit their projects from either the project show page or their project index on their user profile page
- Prevents users from editing projects that they're not owners of
- Creates features tests to test these cases

#### Where should the reviewer start?

Inspect project controller first, I know it can be refactored, but for now it works! Then I'd look at the application controller to see some of the methods added there to prevent non-owners from editing projects.

#### How should this be manually tested?

1.  Login as a user with projects, or sign up and create a project.
2. Navigate to the user profile by clicking on your user's name in the top right corner.
3. Expand one of your user's projects and click 'Edit'.
4. Change something about the project, click 'Save and continue' and see if the change has been made.
5. Once on the show page, you should see an Edit link in the right panel.
6. Try editing the project again by clicking on the Edit link in the project show page.

#### Any background context you want to provide?

Had to fix some stuff regarding project creation first.

#### What are the relevant tickets?

https://www.pivotaltracker.com/story/show/146328405

#### Questions:
  - Do Migrations Need to be ran? 
  - Do Environment Variables need to be set? 
  - Any other deploy steps? 

No additional actions need to be taken.